### PR TITLE
0.2.13-rc4

### DIFF
--- a/SilaAPI/SilaAPI.csproj
+++ b/SilaAPI/SilaAPI.csproj
@@ -10,7 +10,7 @@
     <Authors>Karlo Lorenzana;Jose Luis Morales Ruiz</Authors>
     <Company>DigitalGeko</Company>
     <Product>SilaSDK</Product>
-    <Version>0.2.13-rc3</Version>
+    <Version>0.2.13-rc4</Version>
     <owners>Silamoney</owners>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/SilaAPI/silamoney/client/domain/Transaction.cs
+++ b/SilaAPI/silamoney/client/domain/Transaction.cs
@@ -117,6 +117,6 @@ namespace SilaAPI.silamoney.client.domain
         /// String field value used in the Transaction objet to save timelines
         /// </summary>
         [JsonProperty("timeline")]
-        public List<TimeLine> TimeLine { get; set; }
+        public List<TimeLine> TimeLines { get; set; }
     }
 }

--- a/SilaAPITestProject/ApiTests/Test021GetTransactionsTest.cs
+++ b/SilaAPITestProject/ApiTests/Test021GetTransactionsTest.cs
@@ -21,8 +21,8 @@ namespace SilaApiTest
             Assert.AreEqual(200, response.StatusCode);
             var parsedResponse = (GetTransactionsResult)response.Data;
             Assert.IsTrue(parsedResponse.Transactions.Count > 0);
-            Assert.IsNotNull(parsedResponse.Transactions[0].TimeLine);
-            Assert.IsTrue(parsedResponse.Transactions[0].TimeLine.Count > 0);
+            Assert.IsNotNull(parsedResponse.Transactions[0].TimeLines);
+            Assert.IsTrue(parsedResponse.Transactions[0].TimeLines.Count > 0);
         }
 
     }

--- a/SilaAPITestProject/Utilities/ModelsUtilities.cs
+++ b/SilaAPITestProject/Utilities/ModelsUtilities.cs
@@ -140,7 +140,7 @@ namespace SilaApiTest
                 LastUpdate = "2019-04-03T00:00:00.003Z",
                 CreatedEpoch = 1234567890,
                 LastUpdateEpoch = 1234567899,
-                TimeLine = CreateTimeLines()
+                TimeLines = CreateTimeLines()
             };
 
             transactions.Add(transaction);


### PR DESCRIPTION
Bugfix:

- Revert breaking change on Transaction.TimeLine property. It's name has been rollback to Transaction.TimeLines.