### PR TITLE
V0.2.26

### DIFF
--- a/SilaAPI/RELEASE-NOTES.txt
+++ b/SilaAPI/RELEASE-NOTES.txt
@@ -1,3 +1,12 @@
+v0.2.26
+Enhancements:
+    - Added MatchScore, AccountOwnerName, and EntityName to the response in /get_accounts.
+    - Added business_uuid to the response in /register.
+    - Added IsDefault a new optional input in /register_wallet.
+    - Added AndroidPackageName a new optional input in /plaid_link_token.
+Breaking changes:
+    -Register for BusinessUser does not return BaseResponse anymore, it returns BusinessUserResponse object.
+
 v0.2.24
 New Features:
     -Adding support for /get_institutions.

--- a/SilaAPI/RELEASE-NOTES.txt
+++ b/SilaAPI/RELEASE-NOTES.txt
@@ -1,11 +1,11 @@
 v0.2.26
 Enhancements:
     - Added MatchScore, AccountOwnerName, and EntityName to the response in /get_accounts.
-    - Added business_uuid to the response in /register.
+    - Added BusinessUuid to the response in /register.
     - Added IsDefault a new optional input in /register_wallet.
     - Added AndroidPackageName a new optional input in /plaid_link_token.
 Breaking changes:
-    -Register for BusinessUser does not return BaseResponse anymore, it returns BusinessUserResponse object.
+    - Register for BusinessUser does not return BaseResponse anymore, it returns BusinessUserResponse object.
 
 v0.2.24
 New Features:

--- a/SilaAPI/SilaAPI.csproj
+++ b/SilaAPI/SilaAPI.csproj
@@ -10,7 +10,7 @@
     <Authors>Karlo Lorenzana;Jose Luis Morales Ruiz</Authors>
     <Company>DigitalGeko</Company>
     <Product>SilaSDK</Product>
-    <Version>0.2.24</Version>
+    <Version>0.2.26</Version>
     <owners>Silamoney</owners>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/SilaAPI/silamoney/client/api/SilaApi.cs
+++ b/SilaAPI/silamoney/client/api/SilaApi.cs
@@ -392,10 +392,11 @@ namespace SilaAPI.silamoney.client.api
         /// <param name="userPrivateKey"></param>   
         /// <param name="wallet"></param>
         /// <param name="nickname"></param>
+        /// <param name="isDefault">optional</param>
         /// <returns>ApiResponse&lt;object&gt; object with the server response</returns>
-        public ApiResponse<object> RegisterWallet(string userHandle, string userPrivateKey, UserWallet wallet, string nickname)
+        public ApiResponse<object> RegisterWallet(string userHandle, string userPrivateKey, UserWallet wallet, string nickname, bool? isDefault = null)
         {
-            RegisterWalletMsg body = new RegisterWalletMsg(userHandle, Configuration.AppHandle, wallet, nickname);
+            RegisterWalletMsg body = new RegisterWalletMsg(userHandle, Configuration.AppHandle, wallet, nickname, isDefault);
             var path = "/register_wallet";
 
             return MakeRequest<RegisterWalletResponse>(path, body, userPrivateKey);

--- a/SilaAPI/silamoney/client/api/SilaApi.cs
+++ b/SilaAPI/silamoney/client/api/SilaApi.cs
@@ -229,7 +229,7 @@ namespace SilaAPI.silamoney.client.api
             EntityMsg body = new EntityMsg(user, Configuration.AppHandle);
             var path = "/register";
 
-            return MakeRequest<BaseResponse>(path, body);
+            return MakeRequest<BusinessUserResponse>(path, body);
         }
 
         /// <summary>

--- a/SilaAPI/silamoney/client/api/SilaApi.cs
+++ b/SilaAPI/silamoney/client/api/SilaApi.cs
@@ -911,10 +911,11 @@ namespace SilaAPI.silamoney.client.api
         /// </summary>
         /// <param name="userHandle"></param>
         /// <param name="userPrivateKey"></param>
+        /// <param name="androidPackageName">optional</param>
         /// <returns>ApiResponse&lt;object&gt; object with the server response</returns>
-        public ApiResponse<object> PlaidLinkToken(string userHandle, string userPrivateKey)
+        public ApiResponse<object> PlaidLinkToken(string userHandle, string userPrivateKey, string androidPackageName = null)
         {
-            PlaidLinkTokenMsg body = new PlaidLinkTokenMsg(userHandle, Configuration.AppHandle);
+            PlaidLinkTokenMsg body = new PlaidLinkTokenMsg(userHandle, Configuration.AppHandle, androidPackageName);
             var path = "/plaid_link_token";
 
             return MakeRequest<PlaidLinkTokenResult>(path, body, userPrivateKey);

--- a/SilaAPI/silamoney/client/configuration/Configuration.cs
+++ b/SilaAPI/silamoney/client/configuration/Configuration.cs
@@ -33,7 +33,7 @@ namespace SilaAPI.silamoney.client.configuration
 
         public Configuration()
         {
-            UserAgent = "SilaSDK-.net/0.2.24";
+            UserAgent = "SilaSDK-.net/0.2.26";
             BasePath = Environments.SANDBOX;
             Debug = false;
             Timeout = 100000;

--- a/SilaAPI/silamoney/client/domain/Account.cs
+++ b/SilaAPI/silamoney/client/domain/Account.cs
@@ -42,5 +42,20 @@ namespace SilaAPI.silamoney.client.domain
         /// </summary>
         [JsonProperty("active")]
         public bool Active { get; set; }
+        /// <summary>
+        /// Float field used in the Account object to save account MatchScore
+        /// </summary>
+        [JsonProperty("match_score")]
+        public float? MatchScore { get; set; }
+        /// <summary>
+        /// Float field used in the Account object to save account AccountOwnerName 
+        /// </summary>
+        [JsonProperty("account_owner_name")]
+        public string AccountOwnerName { get; set; }
+        /// <summary>
+        /// Float field used in the Account object to save account EntityName  
+        /// </summary>
+        [JsonProperty("entity_name")]
+        public string EntityName { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/domain/BusinessUserResponse.cs
+++ b/SilaAPI/silamoney/client/domain/BusinessUserResponse.cs
@@ -8,7 +8,7 @@ namespace SilaAPI.silamoney.client.domain
     /// <summary>
     ///  Object used in the Register method for BusinessUser
     /// </summary>   
-    public class BusinessUserResponse : BaseResponseWithoutReference
+    public class BusinessUserResponse : BaseResponse
     {
         /// <summary>
         ///  String field used in the BusinessUserResponse object to save BusinessUuid

--- a/SilaAPI/silamoney/client/domain/BusinessUserResponse.cs
+++ b/SilaAPI/silamoney/client/domain/BusinessUserResponse.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SilaAPI.silamoney.client.domain
+{
+    /// <summary>
+    ///  Object used in the Register method for BusinessUser
+    /// </summary>   
+    public class BusinessUserResponse : BaseResponseWithoutReference
+    {
+        /// <summary>
+        ///  String field used in the BusinessUserResponse object to save BusinessUuid
+        /// </summary>
+        /// <value>BusinessUuid</value>
+        [JsonProperty("business_uuid")]
+        public string BusinessUuid { get; set; }
+    }
+}

--- a/SilaAPI/silamoney/client/domain/EntityData.cs
+++ b/SilaAPI/silamoney/client/domain/EntityData.cs
@@ -56,12 +56,12 @@ namespace SilaAPI.silamoney.client.domain
         /// String field used in the Entity object to save naics code
         /// </summary>
         [JsonProperty("naics_category")]
-        public int NaicsCategory { get; set; }
+        public string NaicsCategory { get; set; }
         /// <summary>
         /// String field used in the Entity object to save naics code
         /// </summary>
         [JsonProperty("naics_subcategory")]
-        public int NaicsSubcategory { get; set; }
+        public string NaicsSubcategory { get; set; }
         /// <summary>
         /// String field used in the Entity object to save business website
         /// </summary>

--- a/SilaAPI/silamoney/client/domain/Header.cs
+++ b/SilaAPI/silamoney/client/domain/Header.cs
@@ -39,16 +39,20 @@ namespace SilaAPI.silamoney.client.domain
         /// </summary>
         [DataMember(Name = "crypto", EmitDefaultValue = false)]
         public Crypto CryptoOption { get; set; }
+        /// <summary>
+        /// string field used in the Header object to save android_package_name
+        /// </summary>
+        [DataMember(Name = "android_package_name", EmitDefaultValue = false)]
+        public string AndroidPackageName { get; set; }
 
         /// <summary>
         /// Header constructor
         /// </summary>
         /// <param name="userHandle"></param>
         /// <param name="authHandle"></param>
+        /// <param name="androidPackageName"></param>
         /// <returns></returns>
-        public Header(string userHandle = default,
-            string authHandle = default
-            )
+        public Header(string userHandle = default, string authHandle = default, string androidPackageName = default)
         {
             UserHandle = userHandle;
             AuthHandle = authHandle;
@@ -56,6 +60,7 @@ namespace SilaAPI.silamoney.client.domain
             VersionOption = Version._02;
             Created = ((int)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds) - 100;
             Reference = Guid.NewGuid().ToString();
+            AndroidPackageName = androidPackageName;
         }
     }
 }

--- a/SilaAPI/silamoney/client/domain/PlaidLinkTokenMsg.cs
+++ b/SilaAPI/silamoney/client/domain/PlaidLinkTokenMsg.cs
@@ -14,10 +14,10 @@ namespace SilaAPI.silamoney.client.domain
         /// </summary>
         /// <param name="userHandle"></param>
         /// <param name="authHandle"></param>
-        public PlaidLinkTokenMsg(string userHandle,
-            string authHandle)
+        /// <param name="androidPackageName"></param>
+        public PlaidLinkTokenMsg(string userHandle, string authHandle, string androidPackageName)
         {
-            Header = new Header(userHandle, authHandle);
+            Header = new Header(userHandle, authHandle, androidPackageName);
         }
     }
 }

--- a/SilaAPI/silamoney/client/domain/RegisterWalletMsg.cs
+++ b/SilaAPI/silamoney/client/domain/RegisterWalletMsg.cs
@@ -26,15 +26,13 @@ namespace SilaAPI.silamoney.client.domain
         /// <param name="authHandle"></param>
         /// <param name="wallet"></param>        
         /// <param name="nickname"></param>
-        public RegisterWalletMsg(string userHandle,
-            string authHandle,
-            UserWallet wallet,
-            string nickname)
+        /// <param name="isDefault"></param>
+        public RegisterWalletMsg(string userHandle, string authHandle, UserWallet wallet, string nickname, bool? isDefault)
         {
             Header = new Header(userHandle, authHandle);
             if (!string.IsNullOrWhiteSpace(wallet.PrivateKey))
                 WalletVerificationSignature = Signer.Sign(wallet.Address, wallet.PrivateKey);
-            Wallet = new Wallet(wallet.Address, Header.Crypto.ETH, nickname);
+            Wallet = new Wallet(wallet.Address, Header.Crypto.ETH, nickname, isDefault);
         }
     }
 }

--- a/SilaAPI/silamoney/client/domain/Wallet.cs
+++ b/SilaAPI/silamoney/client/domain/Wallet.cs
@@ -29,6 +29,12 @@ namespace SilaAPI.silamoney.client.domain
         public string Nickname { get; set; }
 
         /// <summary>
+        /// bool field used in the Wallet object to save default
+        /// </summary>
+        [DataMember(Name = "default", EmitDefaultValue = false)]
+        public bool? IsDefault { get; set; }
+
+        /// <summary>
         /// 
         /// </summary>
         public Wallet() { }
@@ -39,11 +45,13 @@ namespace SilaAPI.silamoney.client.domain
         /// <param name="blockChainAddress"></param>
         /// <param name="blockChainNetwork"></param>
         /// <param name="nickname"></param>
-        public Wallet(string blockChainAddress, Crypto blockChainNetwork, string nickname)
+        /// <param name="isDefault"></param>
+        public Wallet(string blockChainAddress, Crypto blockChainNetwork, string nickname, bool? isDefault)
         {
             BlockChainAddress = blockChainAddress;
             BlockChainNetwork = blockChainNetwork;
             Nickname = nickname;
+            IsDefault = isDefault;
         }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/entities/register/RegisterResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/entities/register/RegisterResponse.cs
@@ -12,5 +12,11 @@ namespace Sila.API.Client.Entities
         public string Message { get; private set; }
         [JsonProperty("status")]
         public string Status { get; private set; }
+        /// <summary>
+        ///  String field used in the RegisterResponse object to save BusinessUuid
+        /// </summary>
+        /// <value>BusinessUuid</value>
+        [JsonProperty("business_uuid")]
+        public string BusinessUuid { get; private set; }
     }
 }

--- a/SilaAPI/silamoney/client/util/SerializationUtil.cs
+++ b/SilaAPI/silamoney/client/util/SerializationUtil.cs
@@ -16,7 +16,7 @@ namespace SilaAPI.silamoney.client.util
                 Newtonsoft.Json.Formatting.None,
                 new JsonSerializerSettings
                 {
-                    ContractResolver = RemoveStringsImplementation.Instance,
+                    //ContractResolver = RemoveStringsImplementation.Instance,
                     NullValueHandling = NullValueHandling.Ignore
                 });
         }

--- a/SilaAPITestProject/ApiTests/Test006RegisterTest.cs
+++ b/SilaAPITestProject/ApiTests/Test006RegisterTest.cs
@@ -41,7 +41,7 @@ namespace SilaApiTest
             var businessResponse = api.Register(businessUser);
 
             Assert.AreEqual(200, fourthResponse.StatusCode);
-            Assert.AreEqual("SUCCESS", ((BaseResponse)businessResponse.Data).Status, $"{businessUser.UserHandle} should register");
+            Assert.AreEqual("SUCCESS", ((BusinessUserResponse)businessResponse.Data).Status, $"{businessUser.UserHandle} should register");
 
             var basicUser = ModelsUtilities.BasicUser;
             var basicResponse = api.Register(basicUser);
@@ -61,7 +61,7 @@ namespace SilaApiTest
             var basicBusinessResponse = api.Register(ModelsUtilities.BasicBusiness);
 
             Assert.AreEqual(200, basicBusinessResponse.StatusCode);
-            var parsedBasicBusinessResponse = (BaseResponse)basicResponse.Data;
+            var parsedBasicBusinessResponse = (BusinessUserResponse)basicBusinessResponse.Data;
             Assert.IsTrue(parsedBasicBusinessResponse.Success);
             Assert.AreEqual("SUCCESS", parsedBasicBusinessResponse.Status);
 

--- a/SilaAPITestProject/ApiTests/Test015LinkAccountTest.cs
+++ b/SilaAPITestProject/ApiTests/Test015LinkAccountTest.cs
@@ -120,7 +120,7 @@ namespace SilaApiTest
                 userPrivateKey: user.PrivateKey,
                 accountName: "sync_direct",
                 accountNumber: "12345678912", 
-                routingNumber: "123456789"
+                routingNumber: "123456780"
             );
             var parsedResponse = (LinkAccountResponse)response.Data;
 
@@ -135,7 +135,7 @@ namespace SilaApiTest
                 userPrivateKey: user.PrivateKey,
                 accountName: "default",
                 accountNumber: "12345678912", 
-                routingNumber: "123456789"
+                routingNumber: "123456780"
             );
             parsedResponse = (LinkAccountResponse)response.Data;
 
@@ -150,7 +150,7 @@ namespace SilaApiTest
                 userPrivateKey: user.PrivateKey,
                 accountName: "unlink",
                 accountNumber: "12345678912", 
-                routingNumber: "123456789"
+                routingNumber: "123456780"
             );
             parsedResponse = (LinkAccountResponse)response.Data;
 
@@ -165,7 +165,7 @@ namespace SilaApiTest
                 userPrivateKey: user.PrivateKey,
                 accountName: "toupdate",
                 accountNumber: "12345678912", 
-                routingNumber: "123456789"
+                routingNumber: "123456780"
             );
             parsedResponse = (LinkAccountResponse)response.Data;
 

--- a/SilaAPITestProject/ApiTests/Test016GetAccountsTest.cs
+++ b/SilaAPITestProject/ApiTests/Test016GetAccountsTest.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace SilaApiTest
 {
     [TestClass]
-    public class Test016_GetAccountsTest
+    public class Test016GetAccountsTest
     {
         SilaApi api = DefaultConfig.Client;
 

--- a/SilaAPITestProject/ApiTests/Test016GetAccountsTest.cs
+++ b/SilaAPITestProject/ApiTests/Test016GetAccountsTest.cs
@@ -18,7 +18,7 @@ namespace SilaApiTest
 
             Assert.AreEqual(200, response.StatusCode, $"{user.UserHandle} should success get_accounts");
             var parsedResponse = (GetAccountsResponse)response.Data;
-            Assert.AreEqual(6, parsedResponse.Accounts.Count, $"{user.UserHandle} must have 3 linked accounts");
+            Assert.AreEqual(5, parsedResponse.Accounts.Count, $"{user.UserHandle} must have 3 linked accounts");
         }
 
         [TestMethod("2 - GetAccounts - Empty user handle failure")]

--- a/SilaAPITestProject/ApiTests/Test016GetAccountsTest.cs
+++ b/SilaAPITestProject/ApiTests/Test016GetAccountsTest.cs
@@ -18,7 +18,7 @@ namespace SilaApiTest
 
             Assert.AreEqual(200, response.StatusCode, $"{user.UserHandle} should success get_accounts");
             var parsedResponse = (GetAccountsResponse)response.Data;
-            Assert.AreEqual(5, parsedResponse.Accounts.Count, $"{user.UserHandle} must have 3 linked accounts");
+            Assert.AreEqual(6, parsedResponse.Accounts.Count, $"{user.UserHandle} must have 3 linked accounts");
         }
 
         [TestMethod("2 - GetAccounts - Empty user handle failure")]


### PR DESCRIPTION
Enhancements:
    - Added MatchScore, AccountOwnerName, and EntityName to the response in /get_accounts.
    - Added BusinessUuid to the response in /register.
    - Added IsDefault a new optional input in /register_wallet.
    - Added AndroidPackageName a new optional input in /plaid_link_token.
Breaking changes:
    -Register for BusinessUser does not return BaseResponse anymore, it returns BusinessUserResponse object.