### PR TITLE
V0.2.41

### DIFF
--- a/SilaAPI/RELEASE-NOTES.txt
+++ b/SilaAPI/RELEASE-NOTES.txt
@@ -1,3 +1,18 @@
+v0.2.41
+Enhancements:              
+    - Added virtual accounts as a type/section and AchCreditEnabled and AchDebitEnabled boolean fields to the response in /get_payment_methods.   
+    - Added PaymentMethodId new optional input field in SearchFilters in /get_transactions.   
+    - Updated uuid to wallet_id input field in internal code in WalletSearchFilters in /get_wallets. 
+    - Added ResponseTimeMs to the response in API returns. 
+    - Added AchCreditEnabled and AchDebitEnabled new optional inputs fields and corresponding response fields in /open_virtual_account. 
+    - Added AchCreditEnabled and AchDebitEnabled new optional inputs fields and corresponding response fields in /update_virtual_account.
+    - Added AchCreditEnabled and AchDebitEnabled boolean fields to the response in /get_virtual_account. 
+    - Added AchCreditEnabled and AchDebitEnabled boolean fields to the response in /get_virtual_accounts. 
+    - Updated identityType input field as optional in /documents.
+New Features:
+    - Added support for /close_virtual_account endpoint.
+    - Added support for /create_test_virtual_account_ach_transaction endpoint.
+
 v0.2.39
 Enhancements:              
     - Added SessionIdentifier new optional input field in Device object in /register.

--- a/SilaAPI/SilaAPI.csproj
+++ b/SilaAPI/SilaAPI.csproj
@@ -10,7 +10,7 @@
     <Authors>Karlo Lorenzana;Jose Luis Morales Ruiz</Authors>
     <Company>DigitalGeko</Company>
     <Product>SilaSDK</Product>
-    <Version>0.2.39</Version>
+    <Version>0.2.41</Version>
     <owners>Silamoney</owners>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/SilaAPI/silamoney/client/api/SilaApi.cs
+++ b/SilaAPI/silamoney/client/api/SilaApi.cs
@@ -730,17 +730,17 @@ namespace SilaAPI.silamoney.client.api
         /// <param name="filename">Do not include the file extension</param>
         /// <param name="mimeType">MIME type for one of Supported Image Formats</param>
         /// <param name="documentType">One of Supported Document Types</param>
-        /// <param name="identityType">Matching Identity Type for Document Type</param>
+        /// <param name="identityType">Matching Identity Type for Document Type optional</param>
         /// <param name="name">Descriptive name of the document</param>
         /// <param name="description">General description of the document</param>
         /// <returns></returns>
-        public ApiResponse<object> UploadDocument(string userHandle, string userPrivateKey, string filePath, string filename, string mimeType, string documentType, string identityType, string name = null, string description = null)
+        public ApiResponse<object> UploadDocument(string userHandle, string userPrivateKey, string filePath, string filename, string mimeType, string documentType, string identityType = null, string name = null, string description = null)
         {
             var path = "/documents";
             FileStream file = new FileStream(filePath, FileMode.Open);
             string hash = Signer.HashFile(file);
             file.Close();
-            DocumentMsg body = new DocumentMsg(Configuration.AppHandle, userHandle, filename, hash, mimeType, documentType, identityType, name, description);
+            DocumentMsg body = new DocumentMsg(Configuration.AppHandle, userHandle, filename, hash, mimeType, documentType, name, description);
             return MakeRequest<DocumentResponse>(path, body, filePath, body.MimeType, userPrivateKey);
         }
 
@@ -1238,27 +1238,31 @@ namespace SilaAPI.silamoney.client.api
         /// <param name="userHandle"></param>
         /// <param name="userPrivateKey"></param>
         /// <param name="virtualAccountName"></param>
+        /// <param name="achCreditEnabled"></param>
+        /// <param name="achDebitEnabled"></param>
         /// <returns></returns>
-        public ApiResponse<object> OpenVirtualAccount(string userHandle, string userPrivateKey, string virtualAccountName)
+        public ApiResponse<object> OpenVirtualAccount(string userHandle, string userPrivateKey, string virtualAccountName, bool? achCreditEnabled = null, bool? achDebitEnabled = null)
         {
-            OpenVirtualAccountMsg body = new OpenVirtualAccountMsg(userHandle, Configuration.AppHandle, virtualAccountName);
+            OpenVirtualAccountMsg body = new OpenVirtualAccountMsg(userHandle, Configuration.AppHandle, virtualAccountName, achCreditEnabled, achDebitEnabled);
             var path = "/open_virtual_account";
 
             return MakeRequest<VirtualAccountResponse>(path, body, userPrivateKey);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="userHandle"></param>
-        /// <param name="userPrivateKey"></param>
-        /// <param name="virtualAccountId"></param>
-        /// <param name="virtualAccountName"></param>
-        /// <param name="isActive"></param>
-        /// <returns></returns>
-        public ApiResponse<object> UpdateVirtualAccount(string userHandle, string userPrivateKey, string virtualAccountId, string virtualAccountName, bool? isActive = true)
+       /// <summary>
+       /// 
+       /// </summary>
+       /// <param name="userHandle"></param>
+       /// <param name="userPrivateKey"></param>
+       /// <param name="virtualAccountId"></param>
+       /// <param name="virtualAccountName"></param>
+       /// <param name="isActive"></param>
+       /// <param name="achCreditEnabled"></param>
+       /// <param name="achDebitEnabled"></param>
+       /// <returns></returns>
+        public ApiResponse<object> UpdateVirtualAccount(string userHandle, string userPrivateKey, string virtualAccountId, string virtualAccountName, bool? isActive = true, bool? achCreditEnabled = null, bool? achDebitEnabled = null)
         {
-            UpdateVirtualAccountMsg body = new UpdateVirtualAccountMsg(userHandle, Configuration.AppHandle, virtualAccountId, virtualAccountName, isActive);
+            UpdateVirtualAccountMsg body = new UpdateVirtualAccountMsg(userHandle, Configuration.AppHandle, virtualAccountId, virtualAccountName, achCreditEnabled, achDebitEnabled, isActive);
             var path = "/update_virtual_account";
 
             return MakeRequest<VirtualAccountResponse>(path, body, userPrivateKey);
@@ -1307,6 +1311,41 @@ namespace SilaAPI.silamoney.client.api
             return MakeRequest<GetPaymentMethodsResponse>(path, body, userPrivateKey);
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="userHandle"></param>
+        /// <param name="userPrivateKey"></param>
+        /// <param name="virtualAccountId"></param>
+        /// <param name="accountNumber"></param>
+        /// <returns></returns>
+        public ApiResponse<object> CloseVirtualAccount(string userHandle, string userPrivateKey, string virtualAccountId, string accountNumber)
+        {
+            CloseVirtualAccountMsg body = new CloseVirtualAccountMsg(userHandle, Configuration.AppHandle, virtualAccountId, accountNumber);
+            var path = "/close_virtual_account";
+            return MakeRequest<VirtualAccountResponse>(path, body, userPrivateKey);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="userHandle"></param>
+        /// <param name="userPrivateKey"></param>
+        /// <param name="amount"></param>
+        /// <param name="virtualAccountNumber"></param>
+        /// <param name="tranCode"></param>
+        /// <param name="entityName"></param>
+        /// <param name="effectiveDate"></param>
+        /// <param name="ced"></param>
+        /// <param name="achName"></param>
+        /// <returns></returns>
+        public ApiResponse<object> CreateTestVirtualAccountAchTransaction(string userHandle, string userPrivateKey, int amount, string virtualAccountNumber, int tranCode, string entityName, DateTime? effectiveDate = null, string ced = null, string achName = null)
+        {
+            CreateTestVirtualAccountAchTransactionMsg body = new CreateTestVirtualAccountAchTransactionMsg(userHandle, Configuration.AppHandle, amount, virtualAccountNumber, tranCode, entityName, effectiveDate, ced, achName);
+            var path = "/create_test_virtual_account_ach_transaction";
+
+            return MakeRequest<BaseResponse>(path, body, userPrivateKey);
+        }
 
         /// <summary>
         /// 

--- a/SilaAPI/silamoney/client/configuration/Configuration.cs
+++ b/SilaAPI/silamoney/client/configuration/Configuration.cs
@@ -33,7 +33,7 @@ namespace SilaAPI.silamoney.client.configuration
 
         public Configuration()
         {
-            UserAgent = "SilaSDK-.net/0.2.39";
+            UserAgent = "SilaSDK-.net/0.2.41";
             BasePath = Environments.SANDBOX;
             Debug = false;
             Timeout = 100000;

--- a/SilaAPI/silamoney/client/domain/BaseResponse.cs
+++ b/SilaAPI/silamoney/client/domain/BaseResponse.cs
@@ -18,5 +18,11 @@ namespace SilaAPI.silamoney.client.domain
         /// </summary>
         [JsonProperty("error_code")]
         public string ErrorCode { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/domain/CloseVirtualAccountMsg.cs
+++ b/SilaAPI/silamoney/client/domain/CloseVirtualAccountMsg.cs
@@ -1,0 +1,35 @@
+﻿using System.Runtime.Serialization;
+
+namespace SilaAPI.silamoney.client.domain
+{   /// <summary>
+    /// DeleteTransactionMsg object used in the close_virtual_account endpoint
+    /// </summary>
+    public partial class CloseVirtualAccountMsg : BaseMessage
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        [DataMember(Name = "virtual_account_id", EmitDefaultValue = false)]
+        public string VirtualAccountId { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [DataMember(Name = "account_number", EmitDefaultValue = false)]
+        public string AccountNumber { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="userHandle"></param>
+        /// <param name="appHandle"></param>
+        /// <param name="virtualAccountId"></param>
+        /// <param name="accountNumber"></param>
+        public CloseVirtualAccountMsg(string userHandle, string appHandle, string virtualAccountId, string accountNumber)
+        {
+            Header = new Header(userHandle, appHandle);
+            VirtualAccountId = virtualAccountId;
+            AccountNumber = accountNumber;
+        }
+    }
+}

--- a/SilaAPI/silamoney/client/domain/CreateTestVirtualAccountAchTransactionMsg.cs
+++ b/SilaAPI/silamoney/client/domain/CreateTestVirtualAccountAchTransactionMsg.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace SilaAPI.silamoney.client.domain
+{   /// <summary>
+    /// DeleteTransactionMsg object used in the create_test_virtual_account_ach_transaction endpoint
+    /// </summary>
+    public partial class CreateTestVirtualAccountAchTransactionMsg : BaseMessage
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        [DataMember(Name = "amount", EmitDefaultValue = false)]
+        public int Amount { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [DataMember(Name = "virtual_account_number", EmitDefaultValue = false)]
+        public string VirtualAccountNumber { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [DataMember(Name = "tran_code", EmitDefaultValue = false)]
+        public int TranCode { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [DataMember(Name = "effective_date", EmitDefaultValue = false)]
+        public string EffectiveDate { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [DataMember(Name = "entity_name", EmitDefaultValue = false)]
+        public string EntityName { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [DataMember(Name = "ced", EmitDefaultValue = false)]
+        public string Ced { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [DataMember(Name = "ach_name", EmitDefaultValue = false)]
+        public string AchName { get; set; }
+
+        ///
+        public CreateTestVirtualAccountAchTransactionMsg(string userHandle, string appHandle, int amount, string virtualAccountNumber, int tranCode, string entityName, DateTime? effectiveDate, string ced, string achName)
+        {
+            Header = new Header(userHandle, appHandle);
+            Amount = amount;
+            VirtualAccountNumber = virtualAccountNumber;
+            TranCode = tranCode;
+            EffectiveDate = effectiveDate.HasValue ? effectiveDate.Value.ToString("yyyy-MM-dd") : null;
+            EntityName = entityName;
+            Ced = ced;
+            AchName = achName;
+        }
+    }
+}

--- a/SilaAPI/silamoney/client/domain/DocumentMsg.cs
+++ b/SilaAPI/silamoney/client/domain/DocumentMsg.cs
@@ -17,8 +17,10 @@ namespace SilaAPI.silamoney.client.domain
         public string MimeType { get; }
         [DataMember(Name = "document_type")]
         public string DocumentType { get; }
+
         [DataMember(Name = "identity_type")]
         public string IdentityType { get; }
+
         [DataMember(Name = "description", EmitDefaultValue = false)]
         public string Description { get; }
 
@@ -31,6 +33,17 @@ namespace SilaAPI.silamoney.client.domain
             MimeType = mimeType;
             DocumentType = documentType;
             IdentityType = identityType;
+            Description = description;
+        }
+
+        public DocumentMsg(string authHandle, string userHandle, string filename, string hash, string mimeType, string documentType, string name, string description)
+        {
+            Header = new Header(userHandle, authHandle);
+            Name = name;
+            Filename = filename;
+            Hash = hash;
+            MimeType = mimeType;
+            DocumentType = documentType;
             Description = description;
         }
     }

--- a/SilaAPI/silamoney/client/domain/GetTransactionsResult.cs
+++ b/SilaAPI/silamoney/client/domain/GetTransactionsResult.cs
@@ -35,8 +35,27 @@ namespace SilaAPI.silamoney.client.domain
         public int TotalCount { get; set; }
         /// <summary>
         /// List of Transaction objects used in the GetTransactionsResult to save transactions
+        /// </summary>        
+        [JsonProperty("transactions")]
+        public List<Transaction> Transactions { get; set; }
+
+        /// <summary>
+        /// 
         /// </summary>
-        public List<Transaction> Transactions { get; set; }        
+        [JsonProperty("pagination")]
+        public Pagination Pagination { get; set; }
+
+        /// <summary>
+        /// String field used in the BaseResponse object to save reference
+        /// </summary>
+        [JsonProperty("reference")]
+        public string Reference { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }
 

--- a/SilaAPI/silamoney/client/domain/OpenVirtualAccountMsg.cs
+++ b/SilaAPI/silamoney/client/domain/OpenVirtualAccountMsg.cs
@@ -15,13 +15,29 @@ namespace SilaAPI.silamoney.client.domain
         /// <summary>
         /// 
         /// </summary>
-        /// <param name="userHandle"></param>
-        /// <param name="appHandle"></param>
-        /// <param name="virtualAccountName"></param>
-        public OpenVirtualAccountMsg(string userHandle, string appHandle, string virtualAccountName)
+        [DataMember(Name = "ach_credit_enabled", EmitDefaultValue = false)]
+        public bool? AchCreditEnabled { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [DataMember(Name = "ach_debit_enabled", EmitDefaultValue = false)]
+        public bool? AchDebitEnabled { get; set; }
+
+       /// <summary>
+       /// 
+       /// </summary>
+       /// <param name="userHandle"></param>
+       /// <param name="appHandle"></param>
+       /// <param name="virtualAccountName"></param>
+       /// <param name="achCreditEnabled"></param>
+       /// <param name="achDebitEnabled"></param>
+        public OpenVirtualAccountMsg(string userHandle, string appHandle, string virtualAccountName, bool? achCreditEnabled, bool? achDebitEnabled)
         {
             Header = new Header(userHandle, appHandle);
             VirtualAccountName = virtualAccountName;
+            AchCreditEnabled = achCreditEnabled;
+            AchDebitEnabled = achDebitEnabled;
         }
     }
 }

--- a/SilaAPI/silamoney/client/domain/PaymentMethods.cs
+++ b/SilaAPI/silamoney/client/domain/PaymentMethods.cs
@@ -179,5 +179,17 @@ namespace SilaAPI.silamoney.client.domain
         [JsonProperty("closed_epoch")]
         public string ClosedEpoch { get; set; }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_credit_enabled")]
+        public bool AchCreditEnabled { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_debit_enabled")]
+        public bool AchDebitEnabled { get; set; }
+
     }
 }

--- a/SilaAPI/silamoney/client/domain/SearchFilters.cs
+++ b/SilaAPI/silamoney/client/domain/SearchFilters.cs
@@ -127,6 +127,12 @@ namespace SilaAPI.silamoney.client.domain
         public string DestinationId { get; set; }
 
         /// <summary>
+        /// 
+        /// </summary>
+        [DataMember(Name = "payment_method_id", EmitDefaultValue = false)]
+        public string PaymentMethodId { get; set; }
+
+        /// <summary>
         /// SearchFilters constructor
         /// </summary>
         /// <param name="transactionId"></param>
@@ -147,6 +153,7 @@ namespace SilaAPI.silamoney.client.domain
         /// <param name="sourceId"></param>
         /// <param name="destinationId"></param>
         /// <param name="processingType"></param>
+        /// <param name="paymentMethodId"></param>
         public SearchFilters(string transactionId = default,
             string referenceId = default,
             Statuses[] statuses = default,
@@ -161,7 +168,7 @@ namespace SilaAPI.silamoney.client.domain
             bool? showTimelines = default,
             string bankAccountName = default,
             string cardName = default,
-            string blockchainAddress = default, string sourceId = default, string destinationId = default, ProcessingType processingType = default
+            string blockchainAddress = default, string sourceId = default, string destinationId = default, ProcessingType processingType = default, string paymentMethodId = default
             ) : base(page, perPage, sortAscending)
         {
 
@@ -180,6 +187,7 @@ namespace SilaAPI.silamoney.client.domain
             SourceId = sourceId;
             DestinationId = destinationId;
             this.ProcessingType = processingType;
+            this.PaymentMethodId = paymentMethodId;
         }
     }
 }

--- a/SilaAPI/silamoney/client/domain/UpdateVirtualAccountMsg.cs
+++ b/SilaAPI/silamoney/client/domain/UpdateVirtualAccountMsg.cs
@@ -28,17 +28,33 @@ namespace SilaAPI.silamoney.client.domain
         /// <summary>
         /// 
         /// </summary>
-        /// <param name="userHandle"></param>
-        /// <param name="appHandle"></param>
-        /// <param name="virtualAccountId"></param>
-        /// <param name="virtualAccountName"></param>
-        /// <param name="active"></param>
-        public UpdateVirtualAccountMsg(string userHandle, string appHandle, string virtualAccountId, string virtualAccountName, bool? active = true)
+        [DataMember(Name = "ach_credit_enabled", EmitDefaultValue = false)]
+        public bool? AchCreditEnabled { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [DataMember(Name = "ach_debit_enabled", EmitDefaultValue = false)]
+        public bool? AchDebitEnabled { get; set; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="userHandle"></param>
+    /// <param name="appHandle"></param>
+    /// <param name="virtualAccountId"></param>
+    /// <param name="virtualAccountName"></param>
+    /// <param name="achCreditEnabled"></param>
+    /// <param name="achDebitEnabled"></param>
+    /// <param name="active"></param>
+        public UpdateVirtualAccountMsg(string userHandle, string appHandle, string virtualAccountId, string virtualAccountName, bool? achCreditEnabled, bool? achDebitEnabled, bool? active = true)
         {
             Header = new Header(userHandle, appHandle);
             VirtualAccountId = virtualAccountId;
             VirtualAccountName = virtualAccountName;
             Active = active;
+            AchCreditEnabled = achCreditEnabled;
+            AchDebitEnabled = achDebitEnabled;
         }
     }
 }

--- a/SilaAPI/silamoney/client/domain/VirtualAccounts.cs
+++ b/SilaAPI/silamoney/client/domain/VirtualAccounts.cs
@@ -52,5 +52,17 @@ namespace SilaAPI.silamoney.client.domain
         /// </summary>
         [JsonProperty("closed")]
         public bool Closed { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_credit_enabled")]
+        public bool AchCreditEnabled { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_debit_enabled")]
+        public bool AchDebitEnabled { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/domain/WalletSearchFilters.cs
+++ b/SilaAPI/silamoney/client/domain/WalletSearchFilters.cs
@@ -29,7 +29,7 @@ namespace SilaAPI.silamoney.client.domain
         /// <summary>
         /// String field used in the SearchFilters object to save uuid
         /// </summary>
-        [DataMember(Name = "uuid", EmitDefaultValue = false)]
+        [DataMember(Name = "wallet_id", EmitDefaultValue = false)]
         public string UuId { get; set; }
 
         /// <summary>

--- a/SilaAPI/silamoney/client/refactored/api/ApiClient.cs
+++ b/SilaAPI/silamoney/client/refactored/api/ApiClient.cs
@@ -24,6 +24,9 @@ namespace Sila.API.Client
             Configuration = Configuration.Default;
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
         public bool Debug { get; set; }
 
         /// <summary>
@@ -85,6 +88,16 @@ namespace Sila.API.Client
             return response;
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="method"></param>
+        /// <param name="postBody"></param>
+        /// <param name="headerParams"></param>
+        /// <param name="filePath"></param>
+        /// <param name="contentType"></param>
+        /// <returns></returns>
         public object CallApi(string path, Method method, object postBody, Dictionary<string, string> headerParams, string filePath, string contentType)
         {
             var request = new RestRequest(path, method, DataFormat.None);

--- a/SilaAPI/silamoney/client/refactored/domain/CryptoEnum.cs
+++ b/SilaAPI/silamoney/client/refactored/domain/CryptoEnum.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
+
+namespace Sila.API.Client.Domain
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class CryptoEnum
+    {
+        /// <summary>
+        /// EnumMember values for CryptoOption field
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum Crypto
+        {
+            /// <summary>
+            /// Value: ETH
+            /// </summary>
+            [EnumMember(Value = "ETH")]
+            ETH = 1
+        }
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/domain/PaymentMethods.cs
+++ b/SilaAPI/silamoney/client/refactored/domain/PaymentMethods.cs
@@ -179,5 +179,17 @@ namespace Sila.API.Client.Domain
         [JsonProperty("closed_epoch")]
         public string ClosedEpoch { get; set; }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_credit_enabled")]
+        public bool AchCreditEnabled { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_debit_enabled")]
+        public bool AchDebitEnabled { get; set; }
+
     }
 }

--- a/SilaAPI/silamoney/client/refactored/domain/SearchFilters.cs
+++ b/SilaAPI/silamoney/client/refactored/domain/SearchFilters.cs
@@ -102,5 +102,11 @@ namespace Sila.API.Client.Domain
         /// </summary>
         [JsonProperty("processing_type")]
         public ProcessingType ProcessingType { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("payment_method_id")]
+        public string PaymentMethodId { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/domain/WalletSearchFilters.cs
+++ b/SilaAPI/silamoney/client/refactored/domain/WalletSearchFilters.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using static Sila.API.Client.Domain.CryptoEnum;
+
+namespace Sila.API.Client.Domain
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class WalletSearchFilters
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("blockchain_address")]     
+        public string BlockChainAddress { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("blockchain_network")]      
+        public Crypto BlockChainNetwork { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("nickname")]
+        public string Nickname { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("wallet_id")]
+        public string UuId { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("page")]
+        public int? Page { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("per_page")]
+        public int? PerPage { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("sort_ascending")]
+        public bool? SortAscending { get; set; }
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/endpoints/accounts/CheckInstantACH/CheckInstantACHResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/accounts/CheckInstantACH/CheckInstantACHResponse.cs
@@ -36,5 +36,11 @@ namespace Sila.API.Client.Accounts
         /// </summary>
         [JsonProperty("qualification_details")]
         public QualificationDetails QualificationDetails { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/accounts/PlaidUpdateLinkToken/PlaidUpdateLinkTokenResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/accounts/PlaidUpdateLinkToken/PlaidUpdateLinkTokenResponse.cs
@@ -2,18 +2,45 @@ using Newtonsoft.Json;
 
 namespace Sila.API.Client.Accounts
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class PlaidUpdateLinkTokenResponse
     {
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("success")]
         public bool Success { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("message")]
         public string Message { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("status")]
         public string Status { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("link_token")]
         public string LinkToken { get; private set; }
 
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("reference")]
         public string Reference { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/accounts/getinstitutions/GetInstitutionsResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/accounts/getinstitutions/GetInstitutionsResponse.cs
@@ -4,23 +4,63 @@ using Sila.API.Client.Domain;
 
 namespace Sila.API.Client.Accounts
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class GetInstitutionsResponse
     {
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("success")]
         public bool Success { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("institutions")]
         public List<Institution> Institutions { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("page")]
         public int Page { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("returned_count")]
         public int ReturnedCount { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("total_count")]
         public int TotalCount { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("pagination")]
         public Pagination Pagination { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("status")]
         public string Status { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("reference")]
         public string Reference { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/accounts/linkaccount/LinkAccountResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/accounts/linkaccount/LinkAccountResponse.cs
@@ -2,23 +2,63 @@ using Newtonsoft.Json;
 
 namespace Sila.API.Client.Accounts
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class LinkAccountResponse
     {
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("success")]
         public bool Success { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("message")]
         public string Message { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("status")]
         public string Status { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("reference")]
         public string Reference { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("account_name")]
         public string AccountName { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("match_score")]
         public float? MatchScore { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("account_owner_name")]
         public string AccountOwnerName { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("entity_name")]
         public string EntityName { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/accounts/updateaccount/UpdateAccountResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/accounts/updateaccount/UpdateAccountResponse.cs
@@ -4,19 +4,44 @@ using Sila.API.Client.Domain;
 
 namespace Sila.API.Client.Accounts
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class UpdateAccountResponse
     {
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("success")]
         public bool Success { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("message")]
         public string Message { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("status")]
         public string Status { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("account")]
         public Account Account { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("changes")]
         public List<Change> Changes { get; private set; }
 
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("reference")]
         public string Reference { get; private set; }
     }

--- a/SilaAPI/silamoney/client/refactored/endpoints/cards/deletecard/DeleteCardResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/cards/deletecard/DeleteCardResponse.cs
@@ -32,5 +32,11 @@ namespace Sila.API.Client.Cards
         /// </summary>
         [JsonProperty("message")]
         public string Message { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/cards/getcards/GetCardsResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/cards/getcards/GetCardsResponse.cs
@@ -40,5 +40,11 @@ namespace Sila.API.Client.Cards
         /// </summary>
         [JsonProperty("pagination")]
         public Pagination Pagination { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/cards/linkcard/LinkCardResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/cards/linkcard/LinkCardResponse.cs
@@ -4,6 +4,9 @@ using Sila.API.Client.Domain;
 
 namespace Sila.API.Client.Cards
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class LinkCardResponse
     {
         /// <summary>
@@ -44,5 +47,11 @@ namespace Sila.API.Client.Cards
         /// </summary>
         [JsonProperty("card_details")]
         public Card CardDetail { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/documents/UploadDocument/UploadDocument.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/documents/UploadDocument/UploadDocument.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using RestSharp;
+using Sila.API.Client.Domain;
+using Sila.API.Client.Exceptions;
+using Sila.API.Client.Utils;
+using SilaAPI.silamoney.client.api;
+using SilaAPI.silamoney.client.util;
+
+namespace Sila.API.Client.UploadDocument
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class UploadDocument : AbstractEndpoint
+    {
+        private static string endpoint = "/documents";
+        private UploadDocument() { }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public static ApiResponse<object> Send(UploadDocumentRequest request)
+        {
+            Dictionary<string, object> body = new Dictionary<string, object>();
+            body.Add("header", new Header
+            {
+                Created = EpochUtils.getEpoch(),
+                AppHandle = AppHandle,
+                UserHandle = request.UserHandle,
+                Crypto = "ETH",
+                Reference = UuidUtils.GetUuid(),
+                Version = "0.2"
+            });
+            body.Add("name", request.Name);
+            body.Add("filename", request.Filename);
+            body.Add("hash", request.Hash);
+            body.Add("mime_type", request.MimeType);
+            body.Add("document_type", request.DocumentType);
+            body.Add("description", request.Description);
+
+            string serializedBody = SerializationUtil.Serialize(body);
+
+            Dictionary<string, string> headers = new Dictionary<string, string>();
+            headers = HeaderUtils.SetAuthSignature(headers, serializedBody);
+
+            IRestResponse response = (IRestResponse)ApiClient.CallApi(endpoint, RestSharp.Method.POST, serializedBody, headers, "application/json");
+
+            return ResponseUtils.PrepareResponse<UploadDocumentResponse>(response);
+        }
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/endpoints/documents/UploadDocument/UploadDocumentRequest.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/documents/UploadDocument/UploadDocumentRequest.cs
@@ -1,0 +1,41 @@
+﻿using Sila.API.Client.Domain;
+
+namespace Sila.API.Client.UploadDocument
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class UploadDocumentRequest
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public string UserHandle { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string Name { get; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string Filename { get; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string Hash { get; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string MimeType { get; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string DocumentType { get; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string Description { get; }
+
+
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/endpoints/documents/UploadDocument/UploadDocumentResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/documents/UploadDocument/UploadDocumentResponse.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Sila.API.Client.Domain;
+
+namespace Sila.API.Client.UploadDocument
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class UploadDocumentResponse
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("success")]
+        public bool Success { get; private set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("message")]
+        public string Message { get; private set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; private set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("reference")]
+        public string Reference { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("reference_id")]
+        public string ReferenceId { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("document_id")]
+        public string DocumentId { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/endpoints/entities/checkkyc/CheckKYCResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/entities/checkkyc/CheckKYCResponse.cs
@@ -56,5 +56,11 @@ namespace Sila.API.Client.Entities
         /// </summary>
         [JsonProperty("valid_kyc_levels")]
         public List<string> ValidKYCLevels { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/entities/checkpartnerkyc/CheckPartnerKycResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/entities/checkpartnerkyc/CheckPartnerKycResponse.cs
@@ -2,19 +2,51 @@ using Newtonsoft.Json;
 
 namespace Sila.API.Client.Entities
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class CheckPartnerKycResponse
     {
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("success")]
         public bool Success { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("reference")]
         public string Reference { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("message")]
         public string Message { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("status")]
         public string Status { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("entity_type")]
         public string EntityType { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("verification_status")]
         public string VerificationStatus { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/entities/register/RegisterResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/entities/register/RegisterResponse.cs
@@ -33,5 +33,11 @@ namespace Sila.API.Client.Entities
         /// <value>BusinessUuid</value>
         [JsonProperty("business_uuid")]
         public string BusinessUuid { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/entities/requestkyc/RequestKycResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/entities/requestkyc/RequestKycResponse.cs
@@ -2,17 +2,45 @@ using Newtonsoft.Json;
 
 namespace Sila.API.Client.Entities
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class RequestKycResponse
     {
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("success")]
         public bool Success { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("reference")]
         public string Reference { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("message")]
         public string Message { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("status")]
         public string Status { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [JsonProperty("verification_uuid")]
         public string VerificationUuid { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/transactions/canceltransaction/CancelTransactionResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/transactions/canceltransaction/CancelTransactionResponse.cs
@@ -38,6 +38,12 @@ namespace Sila.API.Client.Transactions
         /// </summary>
         [JsonProperty("error_code")]
         public string ErrorCode { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }
 

--- a/SilaAPI/silamoney/client/refactored/endpoints/transactions/gettransactions/GetTransactionsResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/transactions/gettransactions/GetTransactionsResponse.cs
@@ -56,5 +56,11 @@ namespace Sila.API.Client.Transactions
         /// </summary>
         [JsonProperty("reference")]
         public string Reference { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/transactions/issuesila/IssueSilaResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/transactions/issuesila/IssueSilaResponse.cs
@@ -58,6 +58,12 @@ namespace Sila.API.Client.Transactions
         /// </summary>
         [JsonProperty("destination_id")]
         public string DestinationId { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }
 

--- a/SilaAPI/silamoney/client/refactored/endpoints/transactions/redeemsila/RedeemSilaResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/transactions/redeemsila/RedeemSilaResponse.cs
@@ -57,6 +57,12 @@ namespace Sila.API.Client.Transactions
         /// </summary>
         [JsonProperty("destination_id")]
         public string DestinationId { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }
 

--- a/SilaAPI/silamoney/client/refactored/endpoints/transactions/reversetransaction/ReverseTransactionResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/transactions/reversetransaction/ReverseTransactionResponse.cs
@@ -32,5 +32,11 @@ namespace Sila.API.Client.Transactions
         /// </summary>
         [JsonProperty("message")]
         public string Message { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/transactions/transfersila/TransferSilaResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/transactions/transfersila/TransferSilaResponse.cs
@@ -65,6 +65,12 @@ namespace Sila.API.Client.Transactions
         /// </summary>
         [JsonProperty("destination_id")]
         public string DestinationId { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }
 

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/closevirtualaccount/CloseVirtualAccount.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/closevirtualaccount/CloseVirtualAccount.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using RestSharp;
+using Sila.API.Client.Domain;
+using Sila.API.Client.Exceptions;
+using Sila.API.Client.Utils;
+using SilaAPI.silamoney.client.api;
+using SilaAPI.silamoney.client.util;
+
+namespace Sila.API.Client.CloseVirtualAccount
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class CloseVirtualAccount : AbstractEndpoint
+    {
+        private static string endpoint = "/close_virtual_account";
+        private CloseVirtualAccount() { }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public static ApiResponse<object> Send(CloseVirtualAccountRequest request)
+        {
+            Dictionary<string, object> body = new Dictionary<string, object>();
+            body.Add("header", new Header
+            {
+                Created = EpochUtils.getEpoch(),
+                AppHandle = AppHandle,
+                UserHandle = request.UserHandle,
+                Crypto = "ETH",
+                Reference = UuidUtils.GetUuid(),
+                Version = "0.2"
+            });
+
+            body.Add("virtual_account_id", request.VirtualAccountId);
+            body.Add("account_number", request.AccountNumber);
+
+            string serializedBody = SerializationUtil.Serialize(body);
+
+            Dictionary<string, string> headers = new Dictionary<string, string>();
+            headers = HeaderUtils.SetAuthSignature(headers, serializedBody);
+
+            IRestResponse response = (IRestResponse)ApiClient.CallApi(endpoint, RestSharp.Method.POST, serializedBody, headers, "application/json");
+
+            return ResponseUtils.PrepareResponse<CloseVirtualAccountResponse>(response);
+        }
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/closevirtualaccount/CloseVirtualAccountRequest.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/closevirtualaccount/CloseVirtualAccountRequest.cs
@@ -1,0 +1,24 @@
+﻿using Sila.API.Client.Domain;
+namespace Sila.API.Client.CloseVirtualAccount
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class CloseVirtualAccountRequest
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public string UserHandle { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string VirtualAccountId { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string AccountNumber { get; set; }
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/closevirtualaccount/CloseVirtualAccountResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/closevirtualaccount/CloseVirtualAccountResponse.cs
@@ -1,0 +1,64 @@
+﻿using Newtonsoft.Json;
+using Sila.API.Client.Domain;
+
+namespace Sila.API.Client.CloseVirtualAccount
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class CloseVirtualAccountResponse
+    {
+        /// <summary>
+        /// String field used in the BaseResponse object to save message 
+        /// </summary>
+        [JsonProperty("message")]
+        public string Message { get; set; }
+        /// <summary>
+        /// String field used in the BaseResponse object to save status
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+        /// <summary>
+        /// Boolean field used to indicate if the response was successful or not
+        /// </summary>
+        [JsonProperty("success")]
+        public bool Success { get; set; }
+
+        /// <summary>
+        /// String field used in the BaseResponse object to save reference
+        /// </summary>
+        [JsonProperty("reference")]
+        public string Reference { get; set; }
+
+        /// <summary>
+        ///  String field used in the TransactionResponse object to save error_code
+        /// </summary>
+        [JsonProperty("error_code")]
+        public string ErrorCode { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("virtual_account")]
+        public VirtualAccounts VirtualAccount { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_credit_enabled")]
+        public bool AchCreditEnabled { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_debit_enabled")]
+        public bool AchDebitEnabled { get; set; }
+
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/createtestvirtualaccountachtransaction/CreateTestVirtualAccountAchTransaction.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/createtestvirtualaccountachtransaction/CreateTestVirtualAccountAchTransaction.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using RestSharp;
+using Sila.API.Client.Domain;
+using Sila.API.Client.Exceptions;
+using Sila.API.Client.Utils;
+using SilaAPI.silamoney.client.api;
+using SilaAPI.silamoney.client.util;
+
+namespace Sila.API.Client.CreateTestVirtualAccountAchTransaction
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class CreateTestVirtualAccountAchTransaction : AbstractEndpoint
+    {
+        private static string endpoint = "/create_test_virtual_account_ach_transaction";
+        private CreateTestVirtualAccountAchTransaction() { }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public static ApiResponse<object> Send(CreateTestVirtualAccountAchTransactionRequest request)
+        {
+            Dictionary<string, object> body = new Dictionary<string, object>();
+            body.Add("header", new Header
+            {
+                Created = EpochUtils.getEpoch(),
+                AppHandle = AppHandle,
+                UserHandle = request.UserHandle,
+                Crypto = "ETH",
+                Reference = UuidUtils.GetUuid(),
+                Version = "0.2"
+            });
+
+            body.Add("amount", request.Amount);
+            body.Add("virtual_account_number", request.VirtualAccountNumber);
+            body.Add("tran_code", request.TranCode);         
+            body.Add("entity_name", request.EntityName);
+            body.Add("ced", request.Ced);
+            body.Add("ach_name", request.AchName);
+            if (request.EffectiveDate != null) body.Add("effective_date", request.EffectiveDate);
+
+            string serializedBody = SerializationUtil.Serialize(body);
+
+            Dictionary<string, string> headers = new Dictionary<string, string>();
+            headers = HeaderUtils.SetAuthSignature(headers, serializedBody);
+
+            IRestResponse response = (IRestResponse)ApiClient.CallApi(endpoint, RestSharp.Method.POST, serializedBody, headers, "application/json");
+
+            return ResponseUtils.PrepareResponse<CreateTestVirtualAccountAchTransactionResponse>(response);
+        }
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/createtestvirtualaccountachtransaction/CreateTestVirtualAccountAchTransactionRequest.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/createtestvirtualaccountachtransaction/CreateTestVirtualAccountAchTransactionRequest.cs
@@ -1,0 +1,43 @@
+﻿using Sila.API.Client.Domain;
+namespace Sila.API.Client.CreateTestVirtualAccountAchTransaction
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class CreateTestVirtualAccountAchTransactionRequest
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public string UserHandle { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public int Amount { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string VirtualAccountNumber { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public int TranCode { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string EffectiveDate { get; set; } = null;
+        /// <summary>
+        /// 
+        /// </summary>
+        public string EntityName { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string Ced { get; set; } = "PAYROLL";
+        /// <summary>
+        /// 
+        /// </summary>
+        public string AchName { get; set; } = "SILA INC";
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/createtestvirtualaccountachtransaction/CreateTestVirtualAccountAchTransactionResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/createtestvirtualaccountachtransaction/CreateTestVirtualAccountAchTransactionResponse.cs
@@ -1,0 +1,46 @@
+﻿using Newtonsoft.Json;
+using Sila.API.Client.Domain;
+
+namespace Sila.API.Client.CreateTestVirtualAccountAchTransaction
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class CreateTestVirtualAccountAchTransactionResponse
+    {
+        /// <summary>
+        /// String field used in the BaseResponse object to save message 
+        /// </summary>
+        [JsonProperty("message")]
+        public string Message { get; set; }
+        /// <summary>
+        /// String field used in the BaseResponse object to save status
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+        /// <summary>
+        /// Boolean field used to indicate if the response was successful or not
+        /// </summary>
+        [JsonProperty("success")]
+        public bool Success { get; set; }
+
+        /// <summary>
+        /// String field used in the BaseResponse object to save reference
+        /// </summary>
+        [JsonProperty("reference")]
+        public string Reference { get; set; }
+
+        /// <summary>
+        ///  String field used in the TransactionResponse object to save error_code
+        /// </summary>
+        [JsonProperty("error_code")]
+        public string ErrorCode { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }     
+
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/getpaymentmethods/GetPaymentMethodsResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/getpaymentmethods/GetPaymentMethodsResponse.cs
@@ -49,6 +49,22 @@ namespace Sila.API.Client.GetPaymentMethods
         [JsonProperty("pagination")]
         public Pagination Pagination { get; set; }
 
-       
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_credit_enabled")]
+        public bool AchCreditEnabled { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_debit_enabled")]
+        public bool AchDebitEnabled { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/getvirtualaccount/GetVirtualAccountResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/getvirtualaccount/GetVirtualAccountResponse.cs
@@ -48,6 +48,22 @@ namespace Sila.API.Client.GetVirtualAccount
         [JsonProperty("balance")]
         public VirtualAccountBalance Balance { get; set; }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_credit_enabled")]
+        public bool AchCreditEnabled { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_debit_enabled")]
+        public bool AchDebitEnabled { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/getvirtualaccounts/GetVirtualAccountsResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/getvirtualaccounts/GetVirtualAccountsResponse.cs
@@ -48,5 +48,23 @@ namespace Sila.API.Client.GetVirtualAccounts
         /// </summary>
         [JsonProperty("pagination")]
         public Pagination Pagination { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_credit_enabled")]
+        public bool AchCreditEnabled { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_debit_enabled")]
+        public bool AchDebitEnabled { get; set; }
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/openvirtualaccount/OpenVirtualAccount.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/openvirtualaccount/OpenVirtualAccount.cs
@@ -37,6 +37,10 @@ namespace Sila.API.Client.OpenVirtualAccount
             });
 
             body.Add("virtual_account_name", request.VirtualAccountName);
+            if (request.AchCreditEnabled != null) body.Add("ach_credit_enabled", request.AchCreditEnabled);
+            if (request.AchDebitEnabled != null) body.Add("ach_debit_enabled", request.AchDebitEnabled);
+
+
 
             string serializedBody = SerializationUtil.Serialize(body);
 

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/openvirtualaccount/OpenVirtualAccountRequest.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/openvirtualaccount/OpenVirtualAccountRequest.cs
@@ -15,5 +15,15 @@ namespace Sila.API.Client.OpenVirtualAccount
         /// 
         /// </summary>
         public string VirtualAccountName { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool? AchCreditEnabled { get; set; } = null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool? AchDebitEnabled { get; set; } = null;
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/openvirtualaccount/OpenVirtualAccountResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/openvirtualaccount/OpenVirtualAccountResponse.cs
@@ -42,5 +42,23 @@ namespace Sila.API.Client.OpenVirtualAccount
         [JsonProperty("virtual_account")]
         public VirtualAccounts VirtualAccount { get; set; }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_credit_enabled")]
+        public bool AchCreditEnabled { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_debit_enabled")]
+        public bool AchDebitEnabled { get; set; }
+
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/updatevirtualaccount/UpdateVirtualAccount.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/updatevirtualaccount/UpdateVirtualAccount.cs
@@ -39,6 +39,8 @@ namespace Sila.API.Client.UpdateVirtualAccount
             body.Add("virtual_account_id", request.VirtualAccountId);
             body.Add("virtual_account_name", request.VirtualAccountName);
             body.Add("active", request.Active);
+            if (request.AchCreditEnabled != null) body.Add("ach_credit_enabled", request.AchCreditEnabled);
+            if (request.AchDebitEnabled != null) body.Add("ach_debit_enabled", request.AchDebitEnabled);
 
             string serializedBody = SerializationUtil.Serialize(body);
 

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/updatevirtualaccount/UpdateVirtualAccountRequest.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/updatevirtualaccount/UpdateVirtualAccountRequest.cs
@@ -21,6 +21,16 @@ namespace Sila.API.Client.UpdateVirtualAccount
         /// <summary>
         /// 
         /// </summary>
-        public bool? Active { get; set; }
+        public bool? Active { get; set; } = true;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool? AchCreditEnabled { get; set; } = null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool? AchDebitEnabled { get; set; } = null;
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/updatevirtualaccount/UpdateVirtualAccountResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/virtualaccount/updatevirtualaccount/UpdateVirtualAccountResponse.cs
@@ -42,5 +42,23 @@ namespace Sila.API.Client.UpdateVirtualAccount
         [JsonProperty("virtual_account")]
         public VirtualAccounts VirtualAccount { get; set; }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_credit_enabled")]
+        public bool AchCreditEnabled { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("ach_debit_enabled")]
+        public bool AchDebitEnabled { get; set; }
+
     }
 }

--- a/SilaAPI/silamoney/client/refactored/endpoints/wallets/getwallets/GetWallets.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/wallets/getwallets/GetWallets.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using RestSharp;
+using Sila.API.Client.Domain;
+using Sila.API.Client.Exceptions;
+using Sila.API.Client.Utils;
+using SilaAPI.silamoney.client.api;
+using SilaAPI.silamoney.client.util;
+
+namespace Sila.API.Client.Cards
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class GetWallets : AbstractEndpoint
+    {
+        private static string endpoint = "/get_wallets";
+        private GetWallets() { }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public static ApiResponse<object> Send(GetWalletsRequest request)
+        {
+            Dictionary<string, object> body = new Dictionary<string, object>();
+            body.Add("header", new Header
+            {
+                Created = EpochUtils.getEpoch(),
+                AppHandle = AppHandle,
+                UserHandle = request.UserHandle,
+                Crypto = "ETH",
+                Reference = UuidUtils.GetUuid(),
+                Version = "0.2"
+            });
+            body.Add("search_filters", request.SearchFilters);
+
+            string serializedBody = SerializationUtil.Serialize(body);
+
+            Dictionary<string, string> headers = new Dictionary<string, string>();
+            headers = HeaderUtils.SetAuthSignature(headers, serializedBody);
+
+            IRestResponse response = (IRestResponse)ApiClient.CallApi(endpoint, RestSharp.Method.POST, serializedBody, headers, "application/json");
+
+            return ResponseUtils.PrepareResponse<GetWalletsResponse>(response);
+        }
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/endpoints/wallets/getwallets/GetWalletsRequest.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/wallets/getwallets/GetWalletsRequest.cs
@@ -1,0 +1,20 @@
+﻿using Sila.API.Client.Domain;
+
+namespace Sila.API.Client.Cards
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class GetWalletsRequest
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public string UserHandle { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public WalletSearchFilters SearchFilters { get; set; }
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/endpoints/wallets/getwallets/GetWalletsResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/wallets/getwallets/GetWalletsResponse.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Sila.API.Client.Domain;
+
+namespace Sila.API.Client.Cards
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class GetWalletsResponse
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("success")]
+        public bool Success { get; private set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("message")]
+        public string Message { get; private set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; private set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("reference")]
+        public string Reference { get; private set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("cards")]
+        public List<Card> Cards { get; internal set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("pagination")]
+        public Pagination Pagination { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
+    }
+}

--- a/SilaAPI/silamoney/client/refactored/endpoints/webhooks/getwebhooks/GetWebhooksResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/webhooks/getwebhooks/GetWebhooksResponse.cs
@@ -52,6 +52,12 @@ namespace Sila.API.Client.GetWebhooks
         /// </summary>
         [JsonProperty("reference")]
         public string Reference { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }
 

--- a/SilaAPI/silamoney/client/refactored/endpoints/webhooks/retrywebhook/RetryWebhookResponse.cs
+++ b/SilaAPI/silamoney/client/refactored/endpoints/webhooks/retrywebhook/RetryWebhookResponse.cs
@@ -36,6 +36,12 @@ namespace Sila.API.Client.RetryWebhook
         /// </summary>
         [JsonProperty("error_code")]
         public string ErrorCode { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty("response_time_ms")]
+        public string ResponseTimeMs { get; set; }
     }
 }
 

--- a/SilaAPITestProject/ApiTests/Test032VirtualAccountTest.cs
+++ b/SilaAPITestProject/ApiTests/Test032VirtualAccountTest.cs
@@ -35,7 +35,6 @@ namespace SilaApiTest
 
         }
 
-
         [TestMethod("2 - GetVirtualAccounts - Successfully retrieve of VirtualAccounts")]
         public void T002GetVirtualAccounts()
         {
@@ -48,11 +47,13 @@ namespace SilaApiTest
             Assert.IsNotNull(parsedResponse.Pagination);
             Assert.IsNotNull(parsedResponse.VirtualAccounts);
             DefaultConfig.VirtualAccountId = parsedResponse.VirtualAccounts[0].VirtualAccountId;
+            DefaultConfig.AccountNumber = parsedResponse.VirtualAccounts[0].AccountNumber;
 
             user = DefaultConfig.SecondUser;
             response = api.GetVirtualAccounts(user.UserHandle, user.PrivateKey);
             parsedResponse = (GetVirtualAccountsResponse)response.Data;
             DefaultConfig.VirtualAccountDisId = parsedResponse.VirtualAccounts[0].VirtualAccountId;
+            DefaultConfig.AccountNumberDis = parsedResponse.VirtualAccounts[0].AccountNumber;
         }
 
         [TestMethod("3 - IssueSila - Successfully issue of VirtualAccount")]
@@ -170,6 +171,41 @@ namespace SilaApiTest
             Assert.IsNotNull(parsedResponse.Message);
             Assert.IsNotNull(parsedResponse.Reference);
             Assert.IsNotNull(parsedResponse.VirtualAccount);
+        }
+
+        [TestMethod("9 - CloseVirtualAccount - Successfully Close of VirtualAccount")]
+        public void T009CloseVirtualAccount()
+        {
+            string virtualAccountId = DefaultConfig.VirtualAccountId;
+            string accountNumber = DefaultConfig.AccountNumber;
+            var user = DefaultConfig.FirstUser;
+            var response = api.CloseVirtualAccount(user.UserHandle, user.PrivateKey, virtualAccountId, accountNumber);
+            var parsedResponse = (BaseResponse)response.Data;
+            Assert.IsTrue(parsedResponse.Success);
+            Assert.IsNotNull(parsedResponse.Message);
+            Assert.IsNotNull(parsedResponse.Status);
+        }
+
+        [TestMethod("10 - CreateTestVirtualAccountAchTransaction - Successfully create of test VirtualAccountAchTransaction")]
+        public void T10CreateTestVirtualAccountAchTransaction()
+        {
+            var user = DefaultConfig.SecondUser;
+            string userHandle = user.UserHandle;
+            string userPrivateKey = user.PrivateKey;
+            int amount = 100;
+            string virtualAccountNumber = DefaultConfig.AccountNumberDis;
+            int tranCode = 22;
+            string entityName = ModelsUtilities.SecondUser.EntityName;
+            DateTime? effectiveDate = null;
+            string ced = "PAYROLL";
+            string achName = "SILA INC";
+            var response = api.CreateTestVirtualAccountAchTransaction(userHandle, userPrivateKey, amount, virtualAccountNumber, tranCode, entityName, effectiveDate, ced, achName);
+            var parsedResponse = (BaseResponse)response.Data;
+            Assert.IsTrue(parsedResponse.Success);
+            Assert.IsNotNull(parsedResponse.Status);
+            Assert.IsNotNull(parsedResponse.Message);
+            Assert.IsNotNull(parsedResponse.Reference);
+            Assert.IsNotNull(parsedResponse.ResponseTimeMs);
         }
     }
 }

--- a/SilaAPITestProject/Utilities/DefaultConfig.cs
+++ b/SilaAPITestProject/Utilities/DefaultConfig.cs
@@ -206,7 +206,9 @@ namespace SilaApiTest
         public static string DocumentId { get; internal set; }
         public static string IdentityUuid { get; internal set; }
         public static string VirtualAccountId { get; internal set; }
-        public static string VirtualAccountDisId { get; internal set; }
+        public static string AccountNumberDis { get; internal set; }        
+        public static string AccountNumber { get; internal set; }
+        public static string VirtualAccountDisId { get; internal set; }        
         public static string EmailUuid { get; internal set; }
         public static string PhoneUuid { get; internal set; }
         public static string AddressUuid { get; internal set; }


### PR DESCRIPTION
v0.2.41
Enhancements:              
- Added virtual accounts as a type/section and AchCreditEnabled and AchDebitEnabled boolean fields to the response in /get_payment_methods.   
- Added PaymentMethodId new optional input field in SearchFilters in /get_transactions.   
- Updated uuid to wallet_id input field in internal code in WalletSearchFilters in /get_wallets. 
- Added ResponseTimeMs to the response in API returns. 
- Added AchCreditEnabled and AchDebitEnabled new optional inputs fields and corresponding response fields in /open_virtual_account. 
- Added AchCreditEnabled and AchDebitEnabled new optional inputs fields and corresponding response fields in /update_virtual_account.
- Added AchCreditEnabled and AchDebitEnabled boolean fields to the response in /get_virtual_account. 
- Added AchCreditEnabled and AchDebitEnabled boolean fields to the response in /get_virtual_accounts. 
- Updated identityType input field as optional in /documents.

New Features:
- Added support for /close_virtual_account endpoint.
- Added support for /create_test_virtual_account_ach_transaction endpoint.