### PR TITLE
ENGRG-897:  Use uuids in handles

### DIFF
--- a/SilaAPITestProject/Utilities/UserConfiguration.cs
+++ b/SilaAPITestProject/Utilities/UserConfiguration.cs
@@ -7,7 +7,7 @@ namespace SilaApiTest {
         public string PrivateKey { get; }
 
         public UserConfiguration() {
-            UserHandle = "netSDK-" + new System.Random().Next();
+            UserHandle = "netSDK-" + System.Guid.NewGuid().ToString();
             var ecKey = Nethereum.Signer.EthECKey.GenerateKey();
             CryptoAddress = ecKey.GetPublicAddress();
             PrivateKey = ecKey.GetPrivateKey();


### PR DESCRIPTION
Use uuids in handles to ensure that the user handle is always unique. This is needed because we're running into collisions with existing handle when we use integers. This probably started happening because now that there are so many entities in the Sandbox database.